### PR TITLE
Projections

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -2,11 +2,11 @@
 
 namespace Comquer\Event;
 
-use Comquer\Event\Store\DeserializableEvent;
+use Comquer\Serialization\Deserializable;
 use Comquer\Event\Store\SerializableEvent;
 use DateTimeImmutable;
 
-abstract class Event implements SerializableEvent, DeserializableEvent
+abstract class Event implements SerializableEvent, Deserializable
 {
     private $occurredOn;
 

--- a/src/Event/Store/SerializableEvent.php
+++ b/src/Event/Store/SerializableEvent.php
@@ -2,7 +2,8 @@
 
 namespace Comquer\Event\Store;
 
-interface SerializableEvent
+use Comquer\Serialization\Serializable;
+
+interface SerializableEvent extends Serializable
 {
-    public function serialize(): array;
 }

--- a/src/Projection/Projection.php
+++ b/src/Projection/Projection.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Comquer\Projection;
+
+use Comquer\Serialization\Deserializable;
+use Comquer\Serialization\Serializable;
+
+interface Projection extends Serializable, Deserializable
+{
+    public function getId(): ProjectionId;
+}

--- a/src/Projection/ProjectionId.php
+++ b/src/Projection/ProjectionId.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Comquer\Projection;
+
+class ProjectionId
+{
+    /** @var string */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Projection/ProjectionRepository.php
+++ b/src/Projection/ProjectionRepository.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Comquer\Projection;
+
+interface ProjectionRepository
+{
+    public function persist(Projection $projection): void;
+
+    public function getById(ProjectionId $id): Projection;
+}

--- a/src/Serialization/Deserializable.php
+++ b/src/Serialization/Deserializable.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Comquer\Serialization;
+
+interface Deserializable
+{
+    public static function deserialize(array $serialized);
+}

--- a/src/Serialization/Serializable.php
+++ b/src/Serialization/Serializable.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Comquer\Serialization;
+
+interface Serializable
+{
+    public function serialize(): array;
+}


### PR DESCRIPTION
A generic design for projections. Every projection MUST:
* have an accesable identifier (`ProjectionId`)
* be serializable via serialize method
* be deserializable via static deserialize method

Those rules are enforced by the `Projection` interface.

There's also an abstraction for the persistence layer, called `ProjectionRepository`.

